### PR TITLE
Support kintone SUBTABLE type

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ e.g. limit, offset are not supported.
 
 ## Road Map
 - [ ] Guess
-- [ ] Subtable data type support
 - [ ] field name mapping
 - [ ] handle certification fot authentication
 
@@ -32,7 +31,7 @@ e.g. limit, offset are not supported.
 - **guest_space_id**: Kintone app belongs to guest space, guest space id is required. (integer, optional)
 - **fields** (required)
   - **name** the field code of Kintone app record will be retrieved.
-  - **type** Column values are converted to this embulk type. Available values options are: boolean, long, double, string, json, timestamp)
+  - **type** Column values are converted to this embulk type. Available values options are: boolean, long, double, string, json, timestamp) Kintone `SUBTABLE` type is loaded as json text.
   - **format** Format of the timestamp if type is timestamp. The format for kintone DATETIME is `%Y-%m-%dT%H:%M:%S%z`.
 
 kintone API has the limitation, therefore this plugin also faces it. See [official documentation](https://developer.kintone.io/hc/en-us/articles/212495188/)

--- a/src/main/java/org/embulk/input/kintone/KintoneAccessor.java
+++ b/src/main/java/org/embulk/input/kintone/KintoneAccessor.java
@@ -5,12 +5,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.cybozu.kintone.client.model.record.field.FieldValue;
 import com.cybozu.kintone.client.model.member.Member;
+import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class KintoneAccessor {
     private final Logger logger = LoggerFactory.getLogger(KintoneAccessor.class);
+    private final Gson gson = new Gson();
 
     private final HashMap<String, FieldValue> record;
     private final String delimiter = "\n";
@@ -30,8 +32,8 @@ public class KintoneAccessor {
                         .reduce((accum, value) -> accum + this.delimiter + value)
                         .orElse("");
             case SUBTABLE:
-                // TODO: support sub table
-                return "";
+                Object subTableValueItem = this.record.get(name).getValue();
+                return gson.toJson(subTableValueItem);
             case CREATOR:
             case MODIFIER:
                 Member m = (Member) this.record.get(name).getValue();

--- a/src/test/java/org/embulk/input/kintone/TestKintoneAccessor.java
+++ b/src/test/java/org/embulk/input/kintone/TestKintoneAccessor.java
@@ -3,6 +3,7 @@ package org.embulk.input.kintone;
 
 import com.cybozu.kintone.client.model.app.form.FieldType;
 import com.cybozu.kintone.client.model.record.field.FieldValue;
+import com.cybozu.kintone.client.model.record.SubTableValueItem;
 import com.cybozu.kintone.client.model.member.Member;
 import org.junit.Test;
 
@@ -24,23 +25,23 @@ public class TestKintoneAccessor {
     public HashMap<String, FieldValue> createTestRecord() {
         HashMap<String, FieldValue> testRecord = new HashMap<>();
 
-        testRecord = TestHelper.addField(testRecord, "文字列__1行", FieldType.SINGLE_LINE_TEXT, "test single text");
-        testRecord = TestHelper.addField(testRecord, "数値", FieldType.NUMBER, this.uniqueKey);
+        TestHelper.addField(testRecord, "文字列__1行", FieldType.SINGLE_LINE_TEXT, "test single text");
+        TestHelper.addField(testRecord, "数値", FieldType.NUMBER, this.uniqueKey);
         this.uniqueKey += 1;
-        testRecord = TestHelper.addField(testRecord, "文字列__複数行", FieldType.MULTI_LINE_TEXT, "test multi text");
-        testRecord = TestHelper.addField(testRecord, "リッチエディター", FieldType.RICH_TEXT, "<div>test rich text<br /></div>");
+        TestHelper.addField(testRecord, "文字列__複数行", FieldType.MULTI_LINE_TEXT, "test multi text");
+        TestHelper.addField(testRecord, "リッチエディター", FieldType.RICH_TEXT, "<div>test rich text<br /></div>");
 
         ArrayList<String> selectedItemList = new ArrayList<>();
         selectedItemList.add("sample1");
         selectedItemList.add("sample2");
-        testRecord = TestHelper.addField(testRecord, "チェックボックス", FieldType.CHECK_BOX, selectedItemList);
-        testRecord = TestHelper.addField(testRecord, "ラジオボタン", FieldType.RADIO_BUTTON, "sample2");
-        testRecord = TestHelper.addField(testRecord, "ドロップダウン", FieldType.DROP_DOWN, "sample3");
-        testRecord = TestHelper.addField(testRecord, "複数選択", FieldType.MULTI_SELECT, selectedItemList);
-        testRecord = TestHelper.addField(testRecord, "リンク", FieldType.LINK, "http://cybozu.co.jp/");
-        testRecord = TestHelper.addField(testRecord, "日付", FieldType.DATE, "2018-01-01");
-        testRecord = TestHelper.addField(testRecord, "時刻", FieldType.TIME, "12:34");
-        testRecord = TestHelper.addField(testRecord, "日時", FieldType.DATETIME, "2018-01-02T02:30:00Z");
+        TestHelper.addField(testRecord, "チェックボックス", FieldType.CHECK_BOX, selectedItemList);
+        TestHelper.addField(testRecord, "ラジオボタン", FieldType.RADIO_BUTTON, "sample2");
+        TestHelper.addField(testRecord, "ドロップダウン", FieldType.DROP_DOWN, "sample3");
+        TestHelper.addField(testRecord, "複数選択", FieldType.MULTI_SELECT, selectedItemList);
+        TestHelper.addField(testRecord, "リンク", FieldType.LINK, "http://cybozu.co.jp/");
+        TestHelper.addField(testRecord, "日付", FieldType.DATE, "2018-01-01");
+        TestHelper.addField(testRecord, "時刻", FieldType.TIME, "12:34");
+        TestHelper.addField(testRecord, "日時", FieldType.DATETIME, "2018-01-02T02:30:00Z");
 
         ArrayList<Member> userList = new ArrayList<>();
         userList.add(testman1);
@@ -54,6 +55,19 @@ public class TestKintoneAccessor {
         orgList.add(testorg1);
         orgList.add(testorg2);
         TestHelper.addField(testRecord, "組織選択", FieldType.ORGANIZATION_SELECT, orgList);
+
+        SubTableValueItem tableItem1 = new SubTableValueItem();
+        tableItem1.setID(1);
+        HashMap<String, FieldValue> tableItemValue1 = new HashMap<>();
+        FieldValue fv1 = new FieldValue();
+        fv1.setType(FieldType.SINGLE_LINE_TEXT);
+        fv1.setValue("sample_text1");
+        tableItemValue1.put("sample field1", fv1);
+        tableItem1.setValue(tableItemValue1);
+        ArrayList<SubTableValueItem> subTableRecords = new ArrayList<>();
+        subTableRecords.add(tableItem1);
+        TestHelper.addField(testRecord, "サブテーブル", FieldType.SUBTABLE, subTableRecords);
+
         return testRecord;
     }
 
@@ -65,7 +79,7 @@ public class TestKintoneAccessor {
         String userSelect = "code1\ncode2";
         String groupSelect = "code3\ncode4";
         String orgSelect = "code5\ncode6";
-
+        String subTableValue = "[{\"id\":1,\"value\":{\"sample field1\":{\"type\":\"SINGLE_LINE_TEXT\",\"value\":\"sample_text1\"}}}]";
         assertEquals(testRecord.get("文字列__1行").getValue(), accessor.get("文字列__1行"));
         assertEquals("1", accessor.get("数値"));
         assertEquals(testRecord.get("文字列__複数行").getValue(), accessor.get("文字列__複数行"));
@@ -81,5 +95,6 @@ public class TestKintoneAccessor {
         assertEquals(userSelect, accessor.get("ユーザー選択"));
         assertEquals(groupSelect, accessor.get("グループ選択"));
         assertEquals(orgSelect, accessor.get("組織選択"));
+        assertEquals(subTableValue, accessor.get("サブテーブル"));
     }
 }


### PR DESCRIPTION
*What this PR does / why we need it:*

Support kintone `SUBTABLE` load with JSON text. Now this type loaded with empty data.

`SUBTABLE` JSON text data format is following [kintone API response field format](https://developer.cybozu.io/hc/ja/articles/202166330-%E3%83%95%E3%82%A3%E3%83%BC%E3%83%AB%E3%83%89%E5%BD%A2%E5%BC%8F)