### PR TITLE
add expand_subtable and handling empty fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ e.g. limit, offset are not supported.
 - **basic_auth_username**:  Kintone basic auth username Please see Kintone basic auth [here](https://jp.cybozu.help/general/en/admin/list_security/list_ip_basic/basic_auth.html) (string, optional)
 - **basic_auth_password**:  Kintone basic auth password (string, optional)
 - **guest_space_id**: Kintone app belongs to guest space, guest space id is required. (integer, optional)
-- **fields** (required)
+- **expand_subtable**: Expand subtabble (boolean, default: `false`)
+- **fields**: If fields is empty, include all available columns (required)
   - **name** the field code of Kintone app record will be retrieved.
   - **type** Column values are converted to this embulk type. Available values options are: boolean, long, double, string, json, timestamp) Kintone `SUBTABLE` type is loaded as json text.
   - **format** Format of the timestamp if type is timestamp. The format for kintone DATETIME is `%Y-%m-%dT%H:%M:%S%z`.

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "io.trocco"
-version = "0.1.9.dev"
+version = "0.1.9.dev2"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "io.trocco"
-version = "0.1.9.dev2"
+version = "0.1.9"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "io.trocco"
-version = "0.1.8"
+version = "0.1.9.dev"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/input/kintone/KintoneClient.java
+++ b/src/main/java/org/embulk/input/kintone/KintoneClient.java
@@ -1,26 +1,42 @@
 package org.embulk.input.kintone;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.kintone.client.AppClient;
 import com.kintone.client.KintoneClientBuilder;
 import com.kintone.client.RecordClient;
 import com.kintone.client.api.record.CreateCursorRequest;
 import com.kintone.client.api.record.CreateCursorResponseBody;
 import com.kintone.client.api.record.GetRecordsByCursorResponseBody;
 import com.kintone.client.exception.KintoneApiRuntimeException;
+import com.kintone.client.model.app.field.FieldProperty;
+import com.kintone.client.model.app.field.SubtableFieldProperty;
+import com.kintone.client.model.record.FieldType;
 import org.embulk.config.ConfigException;
-import org.embulk.util.config.units.ColumnConfig;
+import org.embulk.spi.Column;
+import org.embulk.spi.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class KintoneClient
 {
     private final Logger logger = LoggerFactory.getLogger(KintoneClient.class);
     private static final int FETCH_SIZE = 500;
     private RecordClient recordClient;
+    private AppClient appClient;
 
     public KintoneClient() throws ConfigException
     {
+    }
+
+    @VisibleForTesting
+    protected KintoneClient(AppClient appClient)
+    {
+        this.appClient = appClient;
     }
 
     @SuppressWarnings("StatementWithEmptyBody")
@@ -57,11 +73,12 @@ public class KintoneClient
 
         com.kintone.client.KintoneClient client = builder.build();
         this.recordClient = client.record();
+        this.appClient = client.app();
     }
 
-    public GetRecordsByCursorResponseBody getResponse(final PluginTask task)
+    public GetRecordsByCursorResponseBody getResponse(final PluginTask task, final Schema schema)
     {
-        CreateCursorResponseBody cursor = this.createCursor(task);
+        CreateCursorResponseBody cursor = this.createCursor(task, schema);
         try {
             return this.recordClient.getRecordsByCursor(cursor.getId());
         }
@@ -84,11 +101,15 @@ public class KintoneClient
         }
     }
 
-    public CreateCursorResponseBody createCursor(final PluginTask task)
+    public CreateCursorResponseBody createCursor(final PluginTask task, final Schema schema)
     {
         ArrayList<String> fields = new ArrayList<>();
-        for (ColumnConfig c : task.getFields().getColumns()) {
+        for (Column c : schema.getColumns()) {
             fields.add(c.getName());
+        }
+        if (task.getExpandSubtable()) {
+            List<String> subTableFieldCodes = getFieldCodes(task, FieldType.SUBTABLE);
+            fields.addAll(subTableFieldCodes);
         }
         CreateCursorRequest request = new CreateCursorRequest();
         request.setApp((long) task.getAppId());
@@ -112,5 +133,38 @@ public class KintoneClient
         catch (KintoneApiRuntimeException e) {
             this.logger.error(e.toString());
         }
+    }
+
+    public Map<String, FieldProperty> getFields(final PluginTask task)
+    {
+        Map<String, FieldProperty> fields = this.appClient.getFormFields(task.getAppId());
+        if (task.getExpandSubtable()) {
+            Map<String, FieldProperty> subtableFields = new HashMap<>();
+            List<String> subtableFieldCodes = new ArrayList<>();
+            for (Map.Entry<String, FieldProperty> fieldEntry : fields.entrySet()) {
+                if (fieldEntry.getValue().getType() == FieldType.SUBTABLE) {
+                    subtableFields.putAll(((SubtableFieldProperty) fieldEntry.getValue()).getFields());
+                    subtableFieldCodes.add(fieldEntry.getKey());
+                }
+            }
+            for (String subtableFieldCode : subtableFieldCodes) {
+                fields.remove(subtableFieldCode);
+            }
+            fields.putAll(subtableFields);
+        }
+
+        return fields;
+    }
+
+    public List<String> getFieldCodes(final PluginTask task, FieldType fieldType)
+    {
+        ArrayList<String> fieldCodes = new ArrayList<>();
+        Map<String, FieldProperty> fields = this.appClient.getFormFields(task.getAppId());
+        for (Map.Entry<String, FieldProperty> entry : fields.entrySet()) {
+            if (entry.getValue().getType() == fieldType) {
+                fieldCodes.add(entry.getKey());
+            }
+        }
+        return fieldCodes;
     }
 }

--- a/src/main/java/org/embulk/input/kintone/KintoneInputPlugin.java
+++ b/src/main/java/org/embulk/input/kintone/KintoneInputPlugin.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 public class KintoneInputPlugin
         implements InputPlugin
@@ -180,7 +181,7 @@ public class KintoneInputPlugin
         client.validateAuth(task);
         client.connect(task);
 
-        Map<String, FieldProperty> fields = client.getFields(task);
+        Map<String, FieldProperty> fields = new TreeMap<>(client.getFields(task));
         Builder builder = Schema.builder();
 
         // built in schema

--- a/src/main/java/org/embulk/input/kintone/PluginTask.java
+++ b/src/main/java/org/embulk/input/kintone/PluginTask.java
@@ -44,6 +44,10 @@ public interface PluginTask
     @ConfigDefault("null")
     Optional<String> getQuery();
 
+    @Config("expand_subtable")
+    @ConfigDefault("false")
+    boolean getExpandSubtable();
+
     @Config("fields")
     SchemaConfig getFields();
 }

--- a/src/test/java/org/embulk/input/kintone/TestKintoneClient.java
+++ b/src/test/java/org/embulk/input/kintone/TestKintoneClient.java
@@ -1,5 +1,11 @@
 package org.embulk.input.kintone;
 
+import com.kintone.client.AppClient;
+import com.kintone.client.model.app.field.FieldProperty;
+import com.kintone.client.model.app.field.SingleLineTextFieldProperty;
+import com.kintone.client.model.app.field.SubtableFieldProperty;
+import com.kintone.client.model.record.FieldType;
+
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.spi.InputPlugin;
@@ -7,13 +13,20 @@ import org.embulk.test.TestingEmbulk;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 public class TestKintoneClient
 {
     private ConfigSource config;
     private final KintoneClient client = new KintoneClient();
+    private final AppClient appClient = mock(AppClient.class);
     private static final String BASIC_RESOURCE_PATH = "org/embulk/input/kintone/";
     private static final String SUCCESS_MSG = "Exception should be thrown by this";
     private final org.embulk.util.config.ConfigMapper configMapper = KintoneInputPlugin.CONFIG_MAPPER_FACTORY.createConfigMapper();
@@ -84,5 +97,73 @@ public class TestKintoneClient
             throw new Exception(SUCCESS_MSG);
         });
         assertEquals(SUCCESS_MSG, e.getMessage());
+    }
+
+    @Test
+    public void checkGetFieldsWithoutExpand()
+    {
+        config = loadYamlResource(embulk);
+        PluginTask task = configMapper.map(config, PluginTask.class);
+
+        KintoneClient client = new KintoneClient(appClient);
+
+        Map<String, FieldProperty> fields = new HashMap<>();
+        fields.put("single line1", new SingleLineTextFieldProperty());
+
+        SubtableFieldProperty subtableFieldProperty = new SubtableFieldProperty();
+        Map<String, FieldProperty> subTableFields = new HashMap<>();
+        subTableFields.put("single line2-1", new SingleLineTextFieldProperty());
+        subTableFields.put("single line2-2", new SingleLineTextFieldProperty());
+        subtableFieldProperty.setFields(subTableFields);
+        fields.put("subtable2", subtableFieldProperty);
+        doReturn(fields).when(appClient).getFormFields(1);
+
+        assertEquals(2, client.getFields(task).size());
+        assertTrue(client.getFields(task).keySet().contains("single line1"));
+        assertTrue(client.getFields(task).keySet().contains("subtable2"));
+    }
+
+    @Test
+    public void checkGetFieldsWithExpand()
+    {
+        config = loadYamlResource(embulk);
+        config.set("expand_subtable", true);
+        PluginTask task = configMapper.map(config, PluginTask.class);
+
+        KintoneClient client = new KintoneClient(appClient);
+
+        Map<String, FieldProperty> fields = new HashMap<>();
+        fields.put("single line1", new SingleLineTextFieldProperty());
+
+        SubtableFieldProperty subtableFieldProperty = new SubtableFieldProperty();
+        Map<String, FieldProperty> subTableFields = new HashMap<>();
+        subTableFields.put("single line2-1", new SingleLineTextFieldProperty());
+        subTableFields.put("single line2-2", new SingleLineTextFieldProperty());
+        subtableFieldProperty.setFields(subTableFields);
+        fields.put("subtable2", subtableFieldProperty);
+        doReturn(fields).when(appClient).getFormFields(1);
+
+        assertEquals(3, client.getFields(task).size());
+        assertTrue(client.getFields(task).keySet().contains("single line1"));
+        assertTrue(client.getFields(task).keySet().contains("single line2-1"));
+        assertTrue(client.getFields(task).keySet().contains("single line2-2"));
+    }
+
+    @Test
+    public void checkGetFieldCodes()
+    {
+        config = loadYamlResource(embulk);
+        config.set("expand_subtable", true);
+        PluginTask task = configMapper.map(config, PluginTask.class);
+
+        KintoneClient client = new KintoneClient(appClient);
+
+        Map<String, FieldProperty> fields = new HashMap<>();
+        fields.put("single line1", new SingleLineTextFieldProperty());
+        fields.put("subtable2",  new SubtableFieldProperty());
+        doReturn(fields).when(appClient).getFormFields(1);
+
+        assertEquals(1, client.getFieldCodes(task, FieldType.SUBTABLE).size());
+        assertTrue(client.getFieldCodes(task, FieldType.SUBTABLE).contains("subtable2"));
     }
 }


### PR DESCRIPTION
add one feature and one change.

## Expand subtable

If `expand_subtable` is true, it expands subtable's columns and add them to original record.

## Support empty fields

If `fields` is empty, all columns will be fetched.
