### PR TITLE
fix: some fields which don't have values such as GROUP, etc are shown as column.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "io.trocco"
-version = "0.1.10.dev2"
+version = "0.1.10"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "io.trocco"
-version = "0.1.9"
+version = "0.1.10.dev2"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/input/kintone/KintoneInputPlugin.java
+++ b/src/main/java/org/embulk/input/kintone/KintoneInputPlugin.java
@@ -189,7 +189,10 @@ public class KintoneInputPlugin
         builder.add("$revision", Types.LONG);
 
         for (Map.Entry<String, FieldProperty> fieldEntry : fields.entrySet()) {
-            builder.add(fieldEntry.getKey(), buildType(fieldEntry.getValue().getType()));
+            final Type type = buildType(fieldEntry.getValue().getType());
+            if (type != null) {
+                builder.add(fieldEntry.getKey(), type);
+            }
         }
 
         return builder.build();
@@ -230,8 +233,9 @@ public class KintoneInputPlugin
             case STATUS_ASSIGNEE:
             case TIME:
             case USER_SELECT:
-            default:
                 return Types.STRING;
+            default:
+                return null;
         }
     }
 }


### PR DESCRIPTION
fixed a bug

Some fieldes such as GROUP, REFERENCE_TABLE, etc don't have values, but they are detected as column with string type.
