### PR TITLE
use trocco-io/kintone-java-client

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,6 +14,9 @@ on:
       - opened
       - synchronize
 
+env:
+  TOKEN: "${{ secrets.GPR_TOKEN }}"
+  USERNAME: "${{ secrets.GPR_USERNAME }}"
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -25,3 +25,6 @@ jobs:
           language: java
           gem-path: "./build/gems/*.gem"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+        env:
+          TOKEN: "${{ secrets.GPR_TOKEN }}"
+          USERNAME: "${{ secrets.GPR_USERNAME }}"

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,14 @@ repositories {
     mavenCentral()
 }
 
-group = "io.trocco"
-version = "0.1.11"
+version = {
+    def vd = versionDetails()
+    if (vd.commitDistance == 0 && vd.lastTag ==~ /^[0-9]+\.[0-9]+\.[0-9]$/) {
+        vd.lastTag
+    } else {
+        "0.0.0.${vd.gitHash}"
+    }
+}()
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 group = "io.trocco"
-version = "0.1.10"
+version = "0.1.11"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/shadow-kintone-java-client/build.gradle
+++ b/shadow-kintone-java-client/build.gradle
@@ -6,6 +6,13 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven {
+        url = uri("https://maven.pkg.github.com/trocco-io/kintone-java-client")
+        credentials {
+            username = project.findProperty("gpr.user") ?: System.getenv("USERNAME")
+            password = project.findProperty("gpr.key") ?: System.getenv("TOKEN")
+        }
+   }
 }
 
 group = "${rootProject.group}"
@@ -25,7 +32,7 @@ configurations {
 }
 
 dependencies {
-    compile "com.kintone:kintone-java-client:1.4.0"
+    compile "com.kintone:kintone-java-client:1.4.1-trocco-0.0.1"
 }
 
 shadowJar {

--- a/shadow-kintone-java-client/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/shadow-kintone-java-client/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,12 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-annotations:2.13.2
-com.fasterxml.jackson.core:jackson-core:2.13.2
-com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2
-com.fasterxml.jackson:jackson-bom:2.13.2
-com.kintone:kintone-java-client:1.4.0
+com.fasterxml.jackson.core:jackson-annotations:2.13.4
+com.fasterxml.jackson.core:jackson-core:2.13.4
+com.fasterxml.jackson.core:jackson-databind:2.13.4.2
+com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4
+com.fasterxml.jackson:jackson-bom:2.13.4
+com.kintone:kintone-java-client:1.4.1-trocco-0.0.1
 commons-codec:commons-codec:1.15
 org.apache.httpcomponents.client5:httpclient5:5.1.3
 org.apache.httpcomponents.core5:httpcore5-h2:5.1.3


### PR DESCRIPTION
When calling [`getFormFields`](https://github.com/trocco-io/embulk-input-kintone/blob/eb18de8d7bf6633092f1c2b44a3cfdbf5dfa0890/src/main/java/org/embulk/input/kintone/KintoneClient.java#L140), there might be instances where a JSON parse error occurs.
this is due to a [bug](https://github.com/kintone/kintone-java-client/pull/47#issuecomment-1851164638), so switched to use [trocco-io/kintone-java-client](https://github.com/trocco-io/kintone-java-client)

in trocco-io/kintone-java-client, `defaultValue` handling as `String` to avoid json parse error. refs: https://github.com/kintone/kintone-java-client/compare/master...trocco-io:kintone-java-client:patch-dafaultValue
There is no problem even if the data type changes, as this plugin does not utilize `defaultValue`.




