### PR TITLE
fixed git tags regexp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 version = {
     def vd = versionDetails()
-    if (vd.commitDistance == 0 && vd.lastTag ==~ /^[0-9]+\.[0-9]+\.[0-9]$/) {
+    if (vd.commitDistance == 0 && vd.lastTag ==~ /^[0-9]+\.[0-9]+\.[0-9]+$/) {
         vd.lastTag
     } else {
         "0.0.0.${vd.gitHash}"


### PR DESCRIPTION
missing meta character `+`.

before
```
[dhrs@GM04DGK5 embulk-input-kintone (master)]$ git tag 0.1.11
[dhrs@GM04DGK5 embulk-input-kintone (master)]$ git tag
0.1.0
0.1.1
0.1.10
0.1.11
0.1.2
0.1.3
0.1.7
0.1.8
0.1.9
[dhrs@GM04DGK5 embulk-input-kintone (master)]$ ./gradlew printVersion

> Task :printVersion
0.0.0.bdb90a6527

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 517ms
1 actionable task: 1 executed
```

after
```
[dhrs@GM04DGK5 embulk-input-kintone (fix-gha-regexp)]$ git tag 0.1.11
[dhrs@GM04DGK5 embulk-input-kintone (fix-gha-regexp)]$ git tag
0.1.0
0.1.1
0.1.10
0.1.11
0.1.2
0.1.3
0.1.7
0.1.8
0.1.9
[dhrs@GM04DGK5 embulk-input-kintone (fix-gha-regexp)]$ ./gradlew printVersion

> Task :printVersion
0.1.11

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 546ms
1 actionable task: 1 executed
```