### PR TITLE
Add direct raw value access for calculated fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ $ ./gradlew gem  # -t to watch change of files and rebuild continuously
 
 ## Development
 ```
-$ ./gradew build
-$ ./gradew test
+$ ./gradlew build
+$ ./gradlew test
 ```

--- a/src/main/java/org/embulk/input/kintone/KintoneAccessor.java
+++ b/src/main/java/org/embulk/input/kintone/KintoneAccessor.java
@@ -87,7 +87,7 @@ public class KintoneAccessor
             case NUMBER:
                 return toString(record.getNumberFieldValue(fieldCode), BigDecimal::toString);
             case CALC:
-                return toString(record.getCalcFieldValue(fieldCode), BigDecimal::toString);
+                return record.getCalcFieldRawValue(fieldCode);
             case CHECK_BOX:
                 return toString(record.getCheckBoxFieldValue(fieldCode));
             case RADIO_BUTTON:

--- a/src/test/java/org/embulk/input/kintone/TestKintoneAccessor.java
+++ b/src/test/java/org/embulk/input/kintone/TestKintoneAccessor.java
@@ -106,7 +106,12 @@ public class TestKintoneAccessor
         testRecord.putField("作成日時", new CreatedTimeFieldValue(ZonedDateTime.parse("2012-01-11T11:30:00Z")));
         testRecord.putField("更新者", new ModifierFieldValue(modifier));
         testRecord.putField("更新日時", new UpdatedTimeFieldValue(ZonedDateTime.parse("2012-01-11T11:30:00Z")));
-        testRecord.putField("計算", new CalcFieldValue("1.23E-12"));
+        testRecord.putField("計算(Calc)", new CalcFieldValue("1.23E-12"));
+        testRecord.putField("数値(Calc)", new CalcFieldValue("1234"));
+        testRecord.putField("日時(Calc)", new CalcFieldValue("2012-01-11T11:30:00Z"));
+        testRecord.putField("日付(Calc)", new CalcFieldValue("2012-01-11"));
+        testRecord.putField("時刻(Calc)", new CalcFieldValue("11:30"));
+        testRecord.putField("時間(Calc)", new CalcFieldValue("49:30"));
         FileBody body1 = new FileBody();
         body1.setFileKey("sample_file1");
         FileBody body2 = new FileBody();
@@ -153,7 +158,12 @@ public class TestKintoneAccessor
         assertEquals("2012-01-11T11:30:00Z", accessor.get("作成日時"));
         assertEquals("code10", accessor.get("更新者"));
         assertEquals("2012-01-11T11:30:00Z", accessor.get("更新日時"));
-        assertEquals("1.23E-12", accessor.get("計算"));
+        assertEquals("1.23E-12", accessor.get("計算(Calc)"));
+        assertEquals("1234", accessor.get("数値(Calc)"));
+        assertEquals("2012-01-11T11:30:00Z", accessor.get("日時(Calc)"));
+        assertEquals("2012-01-11", accessor.get("日付(Calc)"));
+        assertEquals("11:30", accessor.get("時刻(Calc)"));
+        assertEquals("49:30", accessor.get("時間(Calc)"));
         assertEquals("sample_file1\nsample_file2", accessor.get("添付ファイル"));
         assertEquals("sample_category1\nsample_category2", accessor.get("カテゴリー"));
         assertEquals("sample_status", accessor.get("ステータス"));

--- a/src/test/java/org/embulk/input/kintone/TestKintoneAccessor.java
+++ b/src/test/java/org/embulk/input/kintone/TestKintoneAccessor.java
@@ -106,7 +106,7 @@ public class TestKintoneAccessor
         testRecord.putField("作成日時", new CreatedTimeFieldValue(ZonedDateTime.parse("2012-01-11T11:30:00Z")));
         testRecord.putField("更新者", new ModifierFieldValue(modifier));
         testRecord.putField("更新日時", new UpdatedTimeFieldValue(ZonedDateTime.parse("2012-01-11T11:30:00Z")));
-        testRecord.putField("計算", new CalcFieldValue(new BigDecimal("1.23E-12")));
+        testRecord.putField("計算", new CalcFieldValue("1.23E-12"));
         FileBody body1 = new FileBody();
         body1.setFileKey("sample_file1");
         FileBody body2 = new FileBody();


### PR DESCRIPTION
## issue 
- https://github.com/primenumber-dev/n-transfer-ui/issues/23273
- https://prime-number.slack.com/archives/C0409DHV806/p1714115269532209

## summary

### before
- The existing process involved converting to BigDecimal.
  - https://github.com/trocco-io/kintone-java-client/blob/patch-dafaultValue/src/main/java/com/kintone/client/model/record/Record.java#L346-L349

- If a value in an unconvertible format was passed, it would result in an error.
  - https://github.com/trocco-io/kintone-java-client/blob/patch-dafaultValue/src/main/java/com/kintone/client/model/record/CalcFieldValue.java#L41-L46
  - https://cybozu.dev/ja/kintone/docs/overview/field-types/#field-type
  - ex: hh:mm
 
<img width="1064" alt="スクリーンショット 2024-04-30 13 32 15" src="https://github.com/trocco-io/embulk-input-kintone/assets/141691813/4f8305df-4d96-4526-bacf-69889aef456c">

### after
- The modifications were made to allow the use of strings directly.
  - https://github.com/trocco-io/kintone-java-client/blob/patch-dafaultValue/src/main/java/com/kintone/client/model/record/Record.java#L357-L360
  - https://github.com/trocco-io/kintone-java-client/blob/patch-dafaultValue/src/main/java/com/kintone/client/model/record/CalcFieldValue.java#L53-L55