### PR TITLE
Make KintoneClient AutoCloseable and ensure cursor is deleted

### DIFF
--- a/src/main/java/org/embulk/input/kintone/KintoneClient.java
+++ b/src/main/java/org/embulk/input/kintone/KintoneClient.java
@@ -125,11 +125,12 @@ public class KintoneClient implements AutoCloseable
         }
     }
 
-    public void deleteCursor()
+    private void deleteCursor()
     {
         if (this.cursorId != null) {
             try {
                 this.recordClient.deleteCursor(this.cursorId);
+                this.cursorId = null;
             }
             catch (KintoneApiRuntimeException e) {
                 this.logger.error(e.toString());

--- a/src/main/java/org/embulk/input/kintone/KintoneClient.java
+++ b/src/main/java/org/embulk/input/kintone/KintoneClient.java
@@ -26,6 +26,7 @@ public class KintoneClient implements AutoCloseable
 {
     private final Logger logger = LoggerFactory.getLogger(KintoneClient.class);
     private static final int FETCH_SIZE = 500;
+    private static final String CURSOR_ALREADY_EXISTS_ERROR = "Cursor already exists: KintoneClient can only generate one cursor per instance.";
     private RecordClient recordClient;
     private AppClient appClient;
     private String cursorId;
@@ -102,6 +103,9 @@ public class KintoneClient implements AutoCloseable
 
     public void createCursor(final PluginTask task, final Schema schema)
     {
+        if (this.cursorId != null) {
+            throw new RuntimeException(CURSOR_ALREADY_EXISTS_ERROR);
+        }
         ArrayList<String> fields = new ArrayList<>();
         for (Column c : schema.getColumns()) {
             fields.add(c.getName());


### PR DESCRIPTION
### Overview
This pull request makes the `KintoneClient` class `AutoCloseable` and ensures that cursors are always deleted to prevent resource leaks.

### Detailed Description
- Implemented the `AutoCloseable` interface for the `KintoneClient` class.
- Added logic in the `close` method to delete cursors.
- Restricted cursor operations to `KintoneClient` only to prevent accidental misuse.
- Improved resource management by ensuring cursors are always deleted using Java's try-with-resources.

### Related Issues
This addresses potential issues with the error: "The maximum valid cursors per domain is 10." There were cases where the cursor was not deleted, leading to the possibility of reaching this limit and causing errors.

### Impact
This change ensures better resource management and prevents errors related to cursor limits. While there should be no major breaking changes for existing code, the restriction of cursor operations to `KintoneClient` may cause minor compatibility issues. Therefore, it requires careful review to ensure all cursors are properly managed.

### Testing
- Verified that cursors are correctly deleted after operations.
- Tested with multiple cursors to ensure the limit is not reached.

### Additional Notes
Please review the changes carefully to ensure compatibility with existing implementations and proper cursor management.